### PR TITLE
Update nzblink-to-download.user.js

### DIFF
--- a/NZB-Loader/nzblink-to-download.user.js
+++ b/NZB-Loader/nzblink-to-download.user.js
@@ -397,7 +397,7 @@ function loadFromNzbIndex(nzb_info, when_failed) {
         onload: function(response) {
             console.log(response)
             let data = JSON.parse(response.responseText);
-            if ( data.total ===  0 ){
+            if ( data.stats.total ===  0 ){
                 return when_failed()
             }
             console.log("Auf nzbindex.nl gefunden")
@@ -409,11 +409,11 @@ function loadFromNzbIndex(nzb_info, when_failed) {
 function loadNzb(nzblnk){
     let nzb_info = parseNzblnkUrl(nzblnk)
 
-    const king = function() {
-        loadFromNzbKing(nzb_info, function() { alert("Keine Nzb gefunden ")})
-    }
 
-    loadFromNzbIndex(nzb_info, king)
+    loadFromNzbKing(nzb_info, function() { alert("Keine Nzb auf NzbKing gefunden ")})
+
+
+    loadFromNzbIndex(nzb_info,  function() { alert("Keine Nzb auf NzbIndex gefunden ")})
 }
 
 // ------------------------------------------------------------


### PR DESCRIPTION
fixed 2 errors:
- #1  code doesn't enter the loadFromNzbKing-function (I don't exactly know why), so an nzb is never found on nzbking 
- changed the check from nzbindex from data.total to data.stats.total, because data.total does not exist. The problem was that the script thought it always found something on nzbindex, even if there was nothing

There are for sure better ways to fix the nzbking-problem, but I'm not an expert.
Feel free to create a better fix.